### PR TITLE
Add UUID so it runs every time

### DIFF
--- a/modules/extract/main.tf
+++ b/modules/extract/main.tf
@@ -1,4 +1,7 @@
 resource "null_resource" "iplist" {
+  triggers {
+    always = "${uuid()}"
+  }
   provisioner "local-exec" {
     command = "bash ${path.module}/Files/asgip.sh ${var.asg} > ${path.module}/${var.ipfile}"
   }


### PR DESCRIPTION
We had problems where it was caching old records. 
Adding a uuid fixes this and causes the null_resource to always run.

